### PR TITLE
Extract the 'value' field in terraform output json

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ In this case, the input to the `artifact_bucket.jq` template file would be:
 Thus, the `artifact_bucket.jq` file would simply be:
 
 ```jq
-.outputs.artifact_bucket.value
+.outputs.artifact_bucket
 ```
 
 #### Build Artifact in JQ Template

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,7 +124,7 @@ terraform apply $tf_flags tf.plan
 # Handle artifacts if deployment action is 'provision' or 'decommission'
 case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     provision )
-        terraform show -json  | jq '.values.outputs // {}' > outputs.json
+        terraform show -json  | jq '.values.outputs // {} | with_entries(.value = .value.value)' > outputs.json
         jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > artifact_inputs.json
         for artifact_file in artifact_*.jq; do
             [ -f "$artifact_file" ] || break


### PR DESCRIPTION
The top level outputs block in terraform output is a metadata block, with the actual field in a sub-block named value. This extracts that value field, making outputs easier to reference for artifact generation.