### PR TITLE
Align Terraform provisioner with Helm/Bicep, harden image & entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
 ARG TERRAFORM_VERSION=1.5.7
-ARG CHECKOV_VERSION=3.2.447
-ARG RUN_IMG=ubuntu:24.04
+ARG CHECKOV_VERSION=3.2.530
+ARG RUN_IMG=debian:13.5-slim
 ARG USER=massdriver
 ARG UID=10001
 
 FROM ${RUN_IMG} AS build
 ARG TERRAFORM_VERSION
 ARG CHECKOV_VERSION
-ARG OPA_VERSION
 
-# install terraform, opa, yq, massdriver cli, kubectl
+# install terraform, yq, massdriver cli, kubectl
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y curl unzip make jq && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl unzip make jq && \
     rm -rf /var/lib/apt/lists/* && \
     curl -s https://api.github.com/repos/massdriver-cloud/xo/releases/latest | jq -r '.assets[] | select(.name | contains("linux-amd64")) | .browser_download_url' | xargs curl -sSL -o xo.tar.gz && tar -xvf xo.tar.gz -C /tmp && mv /tmp/xo /usr/local/bin/ && rm *.tar.gz && \
     curl -sSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform.zip && unzip -d /usr/local/bin/ terraform.zip && rm *.zip && \
@@ -21,21 +20,26 @@ FROM ${RUN_IMG}
 ARG USER
 ARG UID
 
-RUN apt update && apt install -y ca-certificates jq git openssh-client && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates jq git openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p -m 777 /massdriver
 
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --uid $UID \
-    $USER
-RUN chown -R $USER:$USER /massdriver
-USER $USER
+RUN useradd \
+    --create-home \
+    --shell /bin/bash \
+    --uid ${UID} \
+    ${USER} && \
+    chown -R ${USER}:${USER} /massdriver
 
-COPY --from=build /usr/local/bin/* /usr/local/bin/
-COPY entrypoint.sh /usr/local/bin/
+COPY --from=build /usr/local/bin/xo /usr/local/bin/xo
+COPY --from=build /usr/local/bin/terraform /usr/local/bin/terraform
+COPY --from=build /usr/local/bin/checkov /usr/local/bin/checkov
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+USER ${USER}
 
 ENV MASSDRIVER_PROVISIONER=terraform
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -euo pipefail
+# Unmatched globs expand to nothing instead of the literal pattern, so the
+# artifact_*.jq / resource_*.jq loops below simply skip when no files match.
+shopt -s nullglob
 
 # Define colors
 RED='\033[0;31m'
+YELLOW='\033[0;33m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color (reset)
 
@@ -60,17 +64,17 @@ EOF
 evaluate_checkov() {
     if [ "$checkov_enabled" = "true" ]; then
         echo -e "\nEvaluating Checkov policies..."
-        checkov_flags=""
+        checkov_flags=()
 
         if [ "$checkov_quiet" = "true" ]; then
-            checkov_flags+=" --quiet"
+            checkov_flags+=(--quiet)
         fi
         if [ "$checkov_halt_on_failure" = "false" ]; then
-            checkov_flags+=" --soft-fail"
+            checkov_flags+=(--soft-fail)
         fi
 
         # Setting log level error to avoid Checkov's unavoidable WARNING about not downloading external modules
-        LOG_LEVEL=error checkov --repo-root-for-plan-enrichment . --deep-analysis $checkov_flags --framework terraform_plan -f tfplan.json
+        LOG_LEVEL=error checkov --repo-root-for-plan-enrichment . --deep-analysis "${checkov_flags[@]}" --framework terraform_plan -f tfplan.json
         echo -e "${GREEN}Checkov evaluation completed.${NC}"
     fi
 }
@@ -90,11 +94,13 @@ if [ -n "$tf_log" ]; then
     export TF_LOG="$tf_log"
 fi
 
-# Setup envs for Massdriver HTTP state backend 
-MASSDRIVER_SHORT_PACKAGE_NAME=$(echo $MASSDRIVER_PACKAGE_NAME | sed 's/-[a-z0-9]\{4\}$//')
+# Setup envs for Massdriver HTTP state backend
+if [ -z "${MASSDRIVER_INSTANCE_ID:-}" ]; then
+    export MASSDRIVER_INSTANCE_ID=$(echo "$MASSDRIVER_PACKAGE_NAME" | sed 's/-[a-z0-9]\{4\}$//')
+fi
 export TF_HTTP_USERNAME=${MASSDRIVER_DEPLOYMENT_ID}
 export TF_HTTP_PASSWORD=${MASSDRIVER_TOKEN}
-export TF_HTTP_ADDRESS="https://api.massdriver.cloud/state/${MASSDRIVER_SHORT_PACKAGE_NAME}/${MASSDRIVER_STEP_PATH}"
+export TF_HTTP_ADDRESS="https://api.massdriver.cloud/state/${MASSDRIVER_INSTANCE_ID}/${MASSDRIVER_STEP_PATH}"
 export TF_HTTP_LOCK_ADDRESS=${TF_HTTP_ADDRESS}
 export TF_HTTP_UNLOCK_ADDRESS=${TF_HTTP_ADDRESS}
 
@@ -104,15 +110,20 @@ if [ -f "$secrets_path" ]; then
     cp "$secrets_path" "$entrypoint_dir/bundle/secrets.json"
 fi
 
-cd bundle/$MASSDRIVER_STEP_PATH
+# TODO: this can eventually be removed after MASSDRIVER_PACKAGE_NAME is fully deprecated
+if [ -z "${MASSDRIVER_INSTANCE_ID:-}" ]; then
+    export MASSDRIVER_INSTANCE_ID=$(echo "$MASSDRIVER_PACKAGE_NAME" | sed 's/-[a-z0-9]\{4\}$//')
+fi
+
+cd "bundle/$MASSDRIVER_STEP_PATH"
 
 # Copy the params/connections files to the step directory
 cp "$connections_path" _connections.auto.tfvars.json
 cp "$params_path" _params.auto.tfvars.json
 
-tf_flags="-input=false"
+tf_flags=(-input=false)
 if [ "$json_output" = "true" ]; then
-    tf_flags+=" -json"
+    tf_flags+=(-json)
 fi
 
 case $MASSDRIVER_DEPLOYMENT_ACTION in
@@ -124,7 +135,7 @@ case $MASSDRIVER_DEPLOYMENT_ACTION in
         ;;
     decommission )
         command=destroy
-        tf_flags+=" -destroy"
+        tf_flags+=(-destroy)
         ;;
     *)
         echo -e "${RED}Error: Unsupported deployment action '$MASSDRIVER_DEPLOYMENT_ACTION'. Expected 'plan', 'provision', or 'decommission'.${NC}"
@@ -137,7 +148,7 @@ xo provisioner terraform backend http -s "$MASSDRIVER_STEP_PATH" -o backend.tf.j
 setup_ssh
 
 terraform init -input=false
-terraform plan $tf_flags -out tf.plan
+terraform plan "${tf_flags[@]}" -out tf.plan
 
 # Run validations if the command is not 'destroy'
 if [ "$MASSDRIVER_DEPLOYMENT_ACTION" != "decommission" ]; then
@@ -152,26 +163,26 @@ if [ "$MASSDRIVER_DEPLOYMENT_ACTION" = "plan" ]; then
 fi
 
 echo "Applying Terraform plan..."
-terraform apply $tf_flags tf.plan
+terraform apply "${tf_flags[@]}" tf.plan
 
-# Handle artifacts if deployment action is 'provision' or 'decommission'
+# Publish or delete resources based on deployment action
 case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     provision )
         terraform show -json  | jq '.values.outputs // {} | with_entries(.value = .value.value)' > outputs.json
-        jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > artifact_inputs.json
-        for artifact_file in artifact_*.jq; do
-            [ -f "$artifact_file" ] || break
-            field=$(echo "$artifact_file" | sed 's/^artifact_\(.*\).jq$/\1/')
-            echo "Creating artifact for field $field"
-            jq -f "$artifact_file" artifact_inputs.json | xo artifact publish -d "$field" -n "Artifact $field for $name_prefix" -f -
+        jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > resource_inputs.json
+        for resource_file in artifact_*.jq resource_*.jq; do
+            [ -f "$resource_file" ] || continue
+            field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
+            echo -e "\nCreating resource \"$MASSDRIVER_INSTANCE_ID-$field\" in Massdriver..."
+            jq -f "$resource_file" resource_inputs.json | xo resource publish -d "$field" -n "Resource $field for $name_prefix" -f -
         done
         ;;
     decommission )
-        for artifact_file in artifact_*.jq; do
-            [ -f "$artifact_file" ] || break
-            field=$(echo "$artifact_file" | sed 's/^artifact_\(.*\).jq$/\1/')
-            echo "Deleting artifact for field $field"
-            xo artifact delete -d "$field"
+        for resource_file in artifact_*.jq resource_*.jq; do
+            [ -f "$resource_file" ] || continue
+            field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
+            echo -e "\nDeleting resource \"$MASSDRIVER_INSTANCE_ID-$field\" from Massdriver..."
+            xo resource delete -d "$field" || echo -e "${YELLOW}Warning: failed to delete resource for field $field. Continuing decommission.${NC}"
         done
         ;;
 esac


### PR DESCRIPTION
Brings the Terraform provisioner in line with the improvements recently made to the [Helm](https://github.com/massdriver-cloud/provisioner-helm/pull/15), [Bicep](https://github.com/massdriver-cloud/provisioner-bicep/pull/18), and [OpenTofu](https://github.com/massdriver-cloud/provisioner-opentofu/pull/21) provisioners, plus container hardening and a state-backend fix.

## Dockerfile

- **Base image → `debian:13.5-slim`** (was `ubuntu:24.04`), matching the Helm,
  Bicep, and OpenTofu provisioners. Slimmer image and a single base-image family
  to maintain across the provisioner fleet. All runtime deps
  (`ca-certificates jq git openssh-client`) exist under the same names on Debian.
- **Bumped `CHECKOV_VERSION`** `3.2.447` → `3.2.530`.
- **Removed the dangling `ARG OPA_VERSION`** — OPA was no longer installed.
- **`apt` → `apt-get … --no-install-recommends`** in both stages, and added
  `ca-certificates` to the build stage for HTTPS downloads.
- **`adduser` → `useradd --create-home --shell /bin/bash`**, folding the
  `chown` into the same layer (and ensuring the user has a real home dir for
  the SSH config path).
- **Copy specific binaries** (`xo`, `terraform`, `checkov`) instead of the
  wildcard `/usr/local/bin/*`, and copy `entrypoint.sh` to an explicit path.
- **Moved `USER` after the `COPY`s** so copied files are owned correctly.
- Added `ENV DEBIAN_FRONTEND=noninteractive` to the runtime stage; added a
  trailing newline.

## entrypoint.sh

- **`shopt -s nullglob`** so the `artifact_*.jq` / `resource_*.jq` loops skip
  cleanly when no files match (instead of iterating the literal pattern).
- **Artifacts → resources:** loops now match both `artifact_*.jq` and
  `resource_*.jq`, use `xo resource publish` / `xo resource delete` (was
  `xo artifact …`), and `resource_inputs.json` replaces `artifact_inputs.json`.
- **Non-fatal decommission deletes:** a failed `xo resource delete` now logs a
  yellow warning and continues rather than aborting teardown.
- **Quoting/robustness:** converted `checkov_flags` and `tf_flags` from
  whitespace-delimited strings to bash arrays, quoted
  `cd "bundle/$MASSDRIVER_STEP_PATH"`, and switched loop guards from
  `|| break` to `|| continue`.
- **State backend `MASSDRIVER_INSTANCE_ID` fix:** derive the instance ID from
  `MASSDRIVER_PACKAGE_NAME` only when it's **not** already set, instead of
  unconditionally building `MASSDRIVER_SHORT_PACKAGE_NAME`. Uses `${VAR:-}` so
  it's safe under `set -u`. This keeps a provided instance ID intact while
  preserving the legacy package-name fallback for `TF_HTTP_ADDRESS`.
- Improved resource log lines to name the resource
  (`"$MASSDRIVER_INSTANCE_ID-$field"`).