### PR TITLE
Fix resource ID in provisioner logs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -173,15 +173,15 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
         for resource_file in artifact_*.jq resource_*.jq; do
             [ -f "$resource_file" ] || continue
             field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
-            echo -e "\nCreating resource \"$MASSDRIVER_INSTANCE_ID-$field\" in Massdriver..."
-            jq -f "$resource_file" resource_inputs.json | xo resource publish -d "$field" -n "Resource $field for $name_prefix" -f -
+            echo -e "\nCreating resource \"$MASSDRIVER_INSTANCE_ID.$field\" in Massdriver..."
+            jq -f "$resource_file" resource_inputs.json | xo resource publish -d "$field" -n "Resource $field for $MASSDRIVER_INSTANCE_ID" -f -
         done
         ;;
     decommission )
         for resource_file in artifact_*.jq resource_*.jq; do
             [ -f "$resource_file" ] || continue
             field=$(echo "$resource_file" | sed -E 's/^(artifact|resource)_(.*)\.jq$/\2/')
-            echo -e "\nDeleting resource \"$MASSDRIVER_INSTANCE_ID-$field\" from Massdriver..."
+            echo -e "\nDeleting resource \"$MASSDRIVER_INSTANCE_ID.$field\" from Massdriver..."
             xo resource delete -d "$field" || echo -e "${YELLOW}Warning: failed to delete resource for field $field. Continuing decommission.${NC}"
         done
         ;;


### PR DESCRIPTION
The provisioner printed the wrong resource ID on creation/deletion (used - instead of . as separator between instance and field).